### PR TITLE
Fix print stylesheet path

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,6 @@
 	var link = document.createElement( 'link' );
 	link.rel = 'stylesheet';
 	link.type = 'text/css';
-	link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'node_modules/reveal.js/css/print/paper.css';
-	document.getElementsByTagName( 'head' )[0].appendChild( link );
+        link.href = window.location.search.match( /print-pdf/gi ) ? '{{ site.baseurl }}/node_modules/reveal.js/css/print/pdf.css' : '{{ site.baseurl }}/node_modules/reveal.js/css/print/paper.css';
+        document.getElementsByTagName( 'head' )[0].appendChild( link );
 </script>


### PR DESCRIPTION
## Summary
- ensure print CSS links respect site baseurl and point to correct location

## Testing
- `script/cibuild` *(fails: jekyll executable missing)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68ae645974388329ab74f7fa38ffec57